### PR TITLE
PEP8エラーが見つかった場合はCIはFailedとなる

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,2 +1,5 @@
+# coding: utf-8
 # -*- mode: ruby -*-
 pep8.lint
+# PEP8のエラーが見つかった場合はFail
+pep8.count_errors(should_fail: true)


### PR DESCRIPTION
[![CircleCI branch](https://img.shields.io/circleci/project/github/ryosan-470/danger-with-django-sample/failed-too-long.svg?style=flat-square)]()